### PR TITLE
fix: Update Jira workflows to comment only on issues tagged with the correct label

### DIFF
--- a/.github/workflows/comment_issue.yml
+++ b/.github/workflows/comment_issue.yml
@@ -11,20 +11,66 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Jira Login
+      - name: Start workflow if JIRA_CREATE_COMMENT_AUTO is enabled
         if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        run: echo "Starting workflow"
+
+      - name: Check GitHub Issue type
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        id: github_issue_type
+        uses: actions/github-script@v2.0.0
+        with:
+          result-encoding: string
+          script: |
+            // An Issue can be a pull request, you can identify pull requests by the pull_request key
+            const pullRequest = ${{ toJson(github.event.issue.pull_request) }}
+            if(pullRequest) {
+              return "pull-request"
+            } else {
+              return "issue"
+            }
+
+      - name: Check if GitHub Issue has JIRA_ISSUE_LABEL
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        id: github_issue_has_jira_issue_label
+        uses: actions/github-script@v2.0.0
+        env:
+          JIRA_ISSUE_LABEL: ${{ secrets.JIRA_ISSUE_LABEL }}
+        with:
+          result-encoding: string
+          script: |
+            const labels = ${{ toJson(github.event.issue.labels) }}
+            if(labels.find(label => label.name == process.env.JIRA_ISSUE_LABEL)) {
+              return "true"
+            } else {
+              return "false"
+            }
+
+      - name: Continue workflow only for Issues (not Pull Requests) tagged with JIRA_ISSUE_LABEL
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
+        env:
+          GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
+          GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
+        run: echo "GitHub Issue is tracked on Jira, eligilbe to be commented"
+
+      - name: Jira Login
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: login
         uses: atlassian/gajira-login@v2.0.0
         env:
+          GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
+          GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
       - name: Extract Jira number
-        if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: extract_jira_number
         uses: actions/github-script@v2.0.0
         env:
+          GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
+          GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
           JIRA_PROJECT: ${{ secrets.JIRA_PROJECT }}
           GITHUB_TITLE: ${{ github.event.issue.title }}
         with:
@@ -34,9 +80,12 @@ jobs:
           result-encoding: string
 
       - name: Jira Add comment on issue
-        if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: add_comment_jira_issue
         uses: atlassian/gajira-comment@v2.0.0
+        env:
+          GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
+          GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
         with:
           issue: ${{ steps.extract_jira_number.outputs.result }}
           comment: |

--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Start workflow if JIRA_CREATE_ISSUE_AUTO is enabled
+        if: env.JIRA_CREATE_ISSUE_AUTO == 'true'
+        run: echo "Starting workflow"
+
       - name: Jira Login
         if: env.JIRA_CREATE_ISSUE_AUTO == 'true'
         id: login
@@ -35,7 +39,7 @@ jobs:
             _[Github permalink |${{ github.event.issue.html_url }}]_
             {panel}
 
-      - name: Update Jira issue
+      - name: Update Jira issue if JIRA_UPDATE_ISSUE_BODY is defined
         if: env.JIRA_CREATE_ISSUE_AUTO == 'true' && env.JIRA_UPDATE_ISSUE_BODY != ''
         env:
           JIRA_UPDATE_ISSUE_BODY: ${{ secrets.JIRA_UPDATE_ISSUE_BODY }}

--- a/.github/workflows/create_issue_on_label.yml
+++ b/.github/workflows/create_issue_on_label.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Start workflow if GitHub issue is tagged with JIRA_ISSUE_LABEL
+        if: github.event.label.name == env.JIRA_ISSUE_LABEL
+        run: echo "Starting workflow"
+
       - name: Jira Login
         if: github.event.label.name == env.JIRA_ISSUE_LABEL
         id: login
@@ -35,7 +39,7 @@ jobs:
             _[Github permalink |${{ github.event.issue.html_url }}]_
             {panel}
 
-      - name: Update Jira issue
+      - name: Update Jira issue if JIRA_UPDATE_ISSUE_BODY is defined
         if: github.event.label.name == env.JIRA_ISSUE_LABEL && env.JIRA_UPDATE_ISSUE_BODY != ''
         env:
           JIRA_UPDATE_ISSUE_BODY: ${{ secrets.JIRA_UPDATE_ISSUE_BODY }}
@@ -76,4 +80,3 @@ jobs:
               repo: context.repo.repo,
               body: 'Internal ticket created : [${{ steps.create_jira_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }})'
             })
-

--- a/common/.github/workflows/comment_issue.yml
+++ b/common/.github/workflows/comment_issue.yml
@@ -11,20 +11,66 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Jira Login
+      - name: Start workflow if JIRA_CREATE_COMMENT_AUTO is enabled
         if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        run: echo "Starting workflow"
+
+      - name: Check GitHub Issue type
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        id: github_issue_type
+        uses: actions/github-script@v2.0.0
+        with:
+          result-encoding: string
+          script: |
+            // An Issue can be a pull request, you can identify pull requests by the pull_request key
+            const pullRequest = ${{ toJson(github.event.issue.pull_request) }}
+            if(pullRequest) {
+              return "pull-request"
+            } else {
+              return "issue"
+            }
+
+      - name: Check if GitHub Issue has JIRA_ISSUE_LABEL
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        id: github_issue_has_jira_issue_label
+        uses: actions/github-script@v2.0.0
+        env:
+          JIRA_ISSUE_LABEL: ${{ secrets.JIRA_ISSUE_LABEL }}
+        with:
+          result-encoding: string
+          script: |
+            const labels = ${{ toJson(github.event.issue.labels) }}
+            if(labels.find(label => label.name == process.env.JIRA_ISSUE_LABEL)) {
+              return "true"
+            } else {
+              return "false"
+            }
+
+      - name: Continue workflow only for Issues (not Pull Requests) tagged with JIRA_ISSUE_LABEL
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
+        env:
+          GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
+          GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
+        run: echo "GitHub Issue is tracked on Jira, eligilbe to be commented"
+
+      - name: Jira Login
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: login
         uses: atlassian/gajira-login@v2.0.0
         env:
+          GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
+          GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
       - name: Extract Jira number
-        if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: extract_jira_number
         uses: actions/github-script@v2.0.0
         env:
+          GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
+          GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
           JIRA_PROJECT: ${{ secrets.JIRA_PROJECT }}
           GITHUB_TITLE: ${{ github.event.issue.title }}
         with:
@@ -34,9 +80,12 @@ jobs:
           result-encoding: string
 
       - name: Jira Add comment on issue
-        if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
+        if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: add_comment_jira_issue
         uses: atlassian/gajira-comment@v2.0.0
+        env:
+          GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
+          GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
         with:
           issue: ${{ steps.extract_jira_number.outputs.result }}
           comment: |

--- a/common/.github/workflows/create_issue.yml
+++ b/common/.github/workflows/create_issue.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Start workflow if JIRA_CREATE_ISSUE_AUTO is enabled
+        if: env.JIRA_CREATE_ISSUE_AUTO == 'true'
+        run: echo "Starting workflow"
+
       - name: Jira Login
         if: env.JIRA_CREATE_ISSUE_AUTO == 'true'
         id: login
@@ -35,7 +39,7 @@ jobs:
             _[Github permalink |${{ github.event.issue.html_url }}]_
             {panel}
 
-      - name: Update Jira issue
+      - name: Update Jira issue if JIRA_UPDATE_ISSUE_BODY is defined
         if: env.JIRA_CREATE_ISSUE_AUTO == 'true' && env.JIRA_UPDATE_ISSUE_BODY != ''
         env:
           JIRA_UPDATE_ISSUE_BODY: ${{ secrets.JIRA_UPDATE_ISSUE_BODY }}

--- a/common/.github/workflows/create_issue_on_label.yml
+++ b/common/.github/workflows/create_issue_on_label.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Start workflow if GitHub issue is tagged with JIRA_ISSUE_LABEL
+        if: github.event.label.name == env.JIRA_ISSUE_LABEL
+        run: echo "Starting workflow"
+
       - name: Jira Login
         if: github.event.label.name == env.JIRA_ISSUE_LABEL
         id: login
@@ -35,7 +39,7 @@ jobs:
             _[Github permalink |${{ github.event.issue.html_url }}]_
             {panel}
 
-      - name: Update Jira issue
+      - name: Update Jira issue if JIRA_UPDATE_ISSUE_BODY is defined
         if: github.event.label.name == env.JIRA_ISSUE_LABEL && env.JIRA_UPDATE_ISSUE_BODY != ''
         env:
           JIRA_UPDATE_ISSUE_BODY: ${{ secrets.JIRA_UPDATE_ISSUE_BODY }}
@@ -76,4 +80,3 @@ jobs:
               repo: context.repo.repo,
               body: 'Internal ticket created : [${{ steps.create_jira_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }})'
             })
-


### PR DESCRIPTION
Comment issue workflow was also running for pull requests, this fixes that.
Also some extra steps to make the check of feature flags more clear.

As mentioned at:

https://docs.github.com/en/rest/reference/issues#get-an-issue
Note: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response. **You can identify pull requests by the pull_request key**. Be aware that the id of a pull request returned from "Issues" endpoints will be an issue id. To find out the pull request id, use the "List pull requests" endpoint.
